### PR TITLE
[linux_fonts] Add fontconfig missing definition method

### DIFF
--- a/find_system_fonts_filename/linux_fonts.py
+++ b/find_system_fonts_filename/linux_fonts.py
@@ -37,6 +37,14 @@ class FcFontSet(Structure):
     ]
 
 
+def string_to_cstring(string: str) -> c_char_p:
+    return c_char_p(bytes(ord(c) for c in string))
+
+
+FC_FONTFORMAT = string_to_cstring("fontformat")
+FC_FILE = string_to_cstring("file")
+
+
 class LinuxFonts(SystemFonts):
     _font_config = None
     VALID_FONT_FORMATS = [
@@ -57,7 +65,7 @@ class LinuxFonts(SystemFonts):
 
         config = LinuxFonts._font_config.FcInitLoadConfigAndFonts()
         pat = LinuxFonts._font_config.FcPatternCreate()
-        os = LinuxFonts._font_config.FcObjectSetBuild(b"file", b"fontformat", 0)
+        os = LinuxFonts._font_config.FcObjectSetBuild(FC_FILE, FC_FONTFORMAT, 0)
         fs = LinuxFonts._font_config.FcFontList(config, pat, os)
 
         for i in range(fs.contents.nfont):
@@ -66,8 +74,8 @@ class LinuxFonts(SystemFonts):
             font_format_ptr = c_char_p()
 
             if (
-                LinuxFonts._font_config.FcPatternGetString(font, b"fontformat", 0, byref(font_format_ptr)) == FC_RESULT.FC_RESULT_MATCH
-                and LinuxFonts._font_config.FcPatternGetString(font, b"file", 0, byref(file_path_ptr)) == FC_RESULT.FC_RESULT_MATCH
+                LinuxFonts._font_config.FcPatternGetString(font, FC_FONTFORMAT, 0, byref(font_format_ptr)) == FC_RESULT.FC_RESULT_MATCH
+                and LinuxFonts._font_config.FcPatternGetString(font, FC_FILE, 0, byref(file_path_ptr)) == FC_RESULT.FC_RESULT_MATCH
             ):
                 font_format = FC_FONT_FORMAT(font_format_ptr.value)
 

--- a/find_system_fonts_filename/linux_fonts.py
+++ b/find_system_fonts_filename/linux_fonts.py
@@ -58,7 +58,7 @@ class LinuxFonts(SystemFonts):
         config = LinuxFonts._font_config.FcInitLoadConfigAndFonts()
         pat = LinuxFonts._font_config.FcPatternCreate()
         os = LinuxFonts._font_config.FcObjectSetBuild(b"file", b"fontformat", 0)
-        fs = LinuxFonts._font_config.FcFontList(config, pat, None)
+        fs = LinuxFonts._font_config.FcFontList(config, pat, os)
 
         for i in range(fs.contents.nfont):
             font = fs.contents.fonts[i]

--- a/find_system_fonts_filename/linux_fonts.py
+++ b/find_system_fonts_filename/linux_fonts.py
@@ -110,3 +110,19 @@ class LinuxFonts(SystemFonts):
         # https://www.freedesktop.org/software/fontconfig/fontconfig-devel/fcpatternget-type.html
         LinuxFonts._font_config.FcPatternGetString.restype = FC_RESULT
         LinuxFonts._font_config.FcPatternGetString.argtypes = [c_void_p, c_char_p, c_int, POINTER(c_char_p)]
+
+        # https://www.freedesktop.org/software/fontconfig/fontconfig-devel/fcconfigdestroy.html
+        LinuxFonts._font_config.FcConfigDestroy.restype = None
+        LinuxFonts._font_config.FcConfigDestroy.argtypes = [c_void_p]
+
+        # https://www.freedesktop.org/software/fontconfig/fontconfig-devel/fcpatterndestroy.html
+        LinuxFonts._font_config.FcPatternDestroy.restype = None
+        LinuxFonts._font_config.FcPatternDestroy.argtypes = [c_void_p]
+
+        # https://www.freedesktop.org/software/fontconfig/fontconfig-devel/fcobjectsetdestroy.html
+        LinuxFonts._font_config.FcObjectSetDestroy.restype = None
+        LinuxFonts._font_config.FcObjectSetDestroy.argtypes = [c_void_p]
+
+        # https://www.freedesktop.org/software/fontconfig/fontconfig-devel/fcfontsetdestroy.html
+        LinuxFonts._font_config.FcFontSetDestroy.restype = None
+        LinuxFonts._font_config.FcFontSetDestroy.argtypes = [c_void_p]


### PR DESCRIPTION
On Arch Linux, there was an user that was having ``Segmentation fault``.

Here was his configuration:
Python ``3.11.3``
fontconfig version ``2.14.2``

There were 4 methods for which I forgot to write the definition.
Now, with those, it doesn't cause an ``Segmentation fault``.

I don't really know why it would cause an ``Segmentation fault`` on Arch Linux, but not on Ubuntu. It may be a bug with ctype?