### PR TITLE
Correction windows version check, add dwrite locality check and check if the file exist

### DIFF
--- a/find_system_fonts_filename/windows_fonts.py
+++ b/find_system_fonts_filename/windows_fonts.py
@@ -377,13 +377,13 @@ class WindowsFonts(SystemFonts):
 
 class WindowsVersionHelpers:
     @staticmethod
-    def is_windows_version_or_greater(windows_version, major: int, minor: int, service_pack_major: int) -> bool:
+    def is_windows_version_or_greater(windows_version, major: int, minor: int, build: int) -> bool:
         """
         Parameters:
             windows_version: An object from getwindowsversion.
             major (int): The minimum major OS version number.
             minor (int): The minimum minor OS version number.
-            service_pack_major (int): The minimum major Service Pack version number.
+            build (int): The minimum build version number.
         Returns:
             True if the specified version matches or if it is greater than the version of the current Windows OS. Otherwise, False.
         """
@@ -396,13 +396,15 @@ class WindowsVersionHelpers:
             return (
                 windows_version.major == major
                 and windows_version.minor == minor
-                and windows_version.service_pack_major >= service_pack_major
+                and windows_version.build >= build
             )
 
     @staticmethod
     def is_windows_vista_sp2_or_greater(windows_version) -> bool:
-        return WindowsVersionHelpers.is_windows_version_or_greater(windows_version, 6, 0, 2)
+        # From https://www.lifewire.com/windows-version-numbers-2625171
+        return WindowsVersionHelpers.is_windows_version_or_greater(windows_version, 6, 0, 6002)
 
     @staticmethod
     def is_windows_10_or_greater(windows_version) -> bool:
-        return WindowsVersionHelpers.is_windows_version_or_greater(windows_version, 10, 0, 0)
+        # From https://www.lifewire.com/windows-version-numbers-2625171
+        return WindowsVersionHelpers.is_windows_version_or_greater(windows_version, 10, 0, 10240)


### PR DESCRIPTION
- Correct windows version check
- Add dwrite locality. Like this, we can remove the previous try except
- Edit (17 nov 2023) : Add check to verify if the font file exist. If it doesn't, DirectWrite raise an exception, so now, we catch it