### PR TITLE
Add windows vista support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 This tool allows you to get the font filename on your system. It will collect TrueType (.ttf), OpenType (.otf) and TrueType Collection (.ttf) font format.
 
 It uses some APIs to find the font filename:
-- Windows: [DirectWrite API](https://learn.microsoft.com/en-us/windows/win32/directwrite/direct-write-portal)
+- Windows Vista SP2 and more: [DirectWrite API](https://learn.microsoft.com/en-us/windows/win32/directwrite/direct-write-portal)
+- Windows Vista: [Windows Shell API](https://learn.microsoft.com/en-us/windows/win32/shell/shell-entry)
 - macOS: [Core Text API](https://developer.apple.com/documentation/coretext)
 - Linux: [Fontconfig API](https://www.freedesktop.org/wiki/Software/fontconfig/)
 - Android: [NDK Font API](https://developer.android.com/ndk/reference/group/font)
@@ -21,7 +22,7 @@ try:
 except (AndroidLibraryNotFound, FontConfigNotFound, OSNotSupported):
     # Deal with the exception
     # OSNotSupported can only happen in Windows, macOS and Android
-    #   - Windows Vista SP2 and more are supported
+    #   - Windows Vista and more are supported
     #   - macOS 10.6 and more are supported
     #   - Android SDK/API 29 and more are supported
     # FontConfigNotFound can only happen on Linux when Fontconfig could't be found.

--- a/find_system_fonts_filename/windows_fonts.py
+++ b/find_system_fonts_filename/windows_fonts.py
@@ -377,13 +377,13 @@ class WindowsFonts(SystemFonts):
 
 class WindowsVersionHelpers:
     @staticmethod
-    def is_windows_version_or_greater(windows_version, major: int, minor: int, service_pack_major: int) -> bool:
+    def is_windows_version_or_greater(windows_version, major: int, minor: int, build: int) -> bool:
         """
         Parameters:
             windows_version: An object from getwindowsversion.
             major (int): The minimum major OS version number.
             minor (int): The minimum minor OS version number.
-            service_pack_major (int): The minimum major Service Pack version number.
+            build (int): The minimum build version number.
         Returns:
             True if the specified version matches or if it is greater than the version of the current Windows OS. Otherwise, False.
         """
@@ -396,13 +396,15 @@ class WindowsVersionHelpers:
             return (
                 windows_version.major == major
                 and windows_version.minor == minor
-                and windows_version.service_pack_major >= service_pack_major
+                and windows_version.build >= build
             )
 
     @staticmethod
     def is_windows_vista_sp2_or_greater(windows_version) -> bool:
-        return WindowsVersionHelpers.is_windows_version_or_greater(windows_version, 6, 0, 2)
+        # From https://www.lifewire.com/windows-version-numbers-2625171
+        return WindowsVersionHelpers.is_windows_version_or_greater(windows_version, 6, 0, 6002)
 
     @staticmethod
     def is_windows_10_or_greater(windows_version) -> bool:
-        return WindowsVersionHelpers.is_windows_version_or_greater(windows_version, 10, 0, 0)
+        # From https://www.lifewire.com/windows-version-numbers-2625171
+        return WindowsVersionHelpers.is_windows_version_or_greater(windows_version, 10, 0, 10240)


### PR DESCRIPTION
This PR add windows vista support.
It depend on the PR#6, so please merge the #6 before this one.

On windows vista (excluding windows vista sp2), DirectWrite, is not available. GDI is available, but it cannot query the font filename.
The only ways I know to get the font is to use the Shell to obtain the font filename.

From [this website](https://www.python.org/downloads/windows/), we can see: ``Note that Python 3.8.1 cannot be used on Windows XP or earlier.``
So, with this PR, we support all the possible windows version to get the font filename.

