### PR TITLE
Add basic test

### DIFF
--- a/tests/test_fonts_filename.py
+++ b/tests/test_fonts_filename.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from find_system_fonts_filename import get_system_fonts_filename
+from os.path import isfile
+
+
+def test_get_system_fonts_filename():
+    fonts_filename = get_system_fonts_filename()
+
+    for filename in fonts_filename:
+        assert isfile(filename)
+        assert isinstance(filename, str)
+        assert Path(filename).suffix.lstrip(".").strip().lower() in ["ttf", "otf", "ttc", "otc"]
+
+        with open(filename, "rb") as font_file:
+            truetype_signature = b"\x00\x01\x00\x00"
+            opentype_signature = b"OTTO"
+            collection_signature = b"ttcf"
+
+            signature = font_file.read(4)
+            assert signature in [truetype_signature, opentype_signature, collection_signature]


### PR DESCRIPTION
Add a test to verify whether the result of ``get_system_fonts_filename`` corresponds to a valid font file.






