### PR TITLE
Add support for mypy

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -47,11 +47,7 @@ jobs:
         architecture: ${{ matrix.architecture }}
 
     - name: Install Python requirements
-      run: pip install --upgrade --upgrade-strategy eager .
-
-    - name: Install pytest
-      run: |
-        pip install pytest
+      run: pip install --upgrade --upgrade-strategy eager .[dev]
 
     - name: Run tests
       run: |

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -56,3 +56,7 @@ jobs:
     - name: Run tests
       run: |
         pytest
+
+    - name: Typecheck with mypy
+      run: |
+        mypy

--- a/find_system_fonts_filename/android/android_fonts.py
+++ b/find_system_fonts_filename/android/android_fonts.py
@@ -12,6 +12,7 @@ __all__ = ["AndroidFonts"]
 
 class AndroidFonts(SystemFonts):
 
+    @staticmethod
     def get_system_fonts_filename() -> Set[str]:
         android = Android()
         fonts_filename = set()
@@ -37,14 +38,17 @@ class AndroidFonts(SystemFonts):
         return fonts_filename
 
 
-    def install_font(font_filename: Path, windows_flags: bool) -> None:
+    @staticmethod
+    def install_font(font_filename: Path, add_font_to_registry: bool = False) -> None:
         raise OSNotSupported("You cannot install font on android.")
 
 
-    def uninstall_font(font_filename: Path, windows_flags: bool) -> None:
+    @staticmethod
+    def uninstall_font(font_filename: Path, remove_font_in_registry: bool) -> None:
         raise OSNotSupported("You cannot uninstall font on android.")
 
 
+    @staticmethod
     @contextmanager
     def _silence_stderr_and_stdout():
         # From: https://stackoverflow.com/a/75037627/15835974

--- a/find_system_fonts_filename/fonts_filename.py
+++ b/find_system_fonts_filename/fonts_filename.py
@@ -2,7 +2,7 @@ import sys
 from os import name
 from pathlib import Path
 from platform import system
-from typing import Set
+from typing import Set, Type
 from .exceptions import OSNotSupported
 from .system_fonts import SystemFonts
 
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-def get_system_fonts_class() -> SystemFonts:
+def get_system_fonts_class() -> Type[SystemFonts]:
     system_name = system()
 
     if system_name == "Windows":

--- a/find_system_fonts_filename/mac/mac_fonts.py
+++ b/find_system_fonts_filename/mac/mac_fonts.py
@@ -16,6 +16,7 @@ class MacFonts(SystemFonts):
     # So, we also need to check the file extension to see if the file is valid.
     VALID_FONT_FORMATS = ["ttf", "otf", "ttc", "otc"]
 
+    @staticmethod
     def get_system_fonts_filename() -> Set[str]:
         if not MacVersionHelpers.is_mac_version_or_greater(10, 6):
             raise OSNotSupported("FindSystemFontsFilename only works on Mac 10.6 or more")
@@ -60,7 +61,8 @@ class MacFonts(SystemFonts):
         return fonts_filename
 
 
-    def install_font(font_filename: Path, windows_flags: bool) -> None:
+    @staticmethod
+    def install_font(font_filename: Path, add_font_to_registry: bool = False) -> None:
         if not MacVersionHelpers.is_mac_version_or_greater(10, 6):
             raise OSNotSupported("FindSystemFontsFilename only works on Mac 10.6 or more")
 
@@ -79,7 +81,8 @@ class MacFonts(SystemFonts):
             raise FindSystemFontsFilenameException(f"The font file \"{font_filename}\" could not be installed.")
 
 
-    def uninstall_font(font_filename: Path, windows_flags: bool) -> None:
+    @staticmethod
+    def uninstall_font(font_filename: Path, remove_font_in_registry: bool) -> None:
         if not MacVersionHelpers.is_mac_version_or_greater(10, 6):
             raise OSNotSupported("FindSystemFontsFilename only works on Mac 10.6 or more")
 

--- a/find_system_fonts_filename/mac/version_helpers.py
+++ b/find_system_fonts_filename/mac/version_helpers.py
@@ -18,7 +18,7 @@ class MacVersionHelpers:
 
         system_major, system_minor = mac_ver()[0].split(".")[:2]
 
-        system_major = int(system_major)
-        system_minor = int(system_minor)
+        system_major_int = int(system_major)
+        system_minor_int = int(system_minor)
 
-        return system_major > minimum_major or (system_major == minimum_major and system_minor >= minimum_minor)
+        return system_major_int > minimum_major or (system_major_int == minimum_major and system_minor_int >= minimum_minor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,12 @@ version = { attr = "find_system_fonts_filename.__init__.__version__" }
 
 [tool.setuptools.packages.find]
 include = ["find_system_fonts_filename*"]
+
+[tool.mypy]
+exclude = "build"
+files = ["."]
+warn_unused_configs = true
+
+[[tool.mypy.overrides]]
+module = ["comtypes.*"]
+follow_untyped_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,19 @@ warn_unused_configs = true
 [[tool.mypy.overrides]]
 module = ["comtypes.*"]
 follow_untyped_imports = true
+
+[[tool.mypy.overrides]]
+module = "find_system_fonts_filename.android.*"
+platform = "android"
+
+[[tool.mypy.overrides]]
+module = "find_system_fonts_filename.mac.*"
+platform = "darwin"
+
+[[tool.mypy.overrides]]
+module = "find_system_fonts_filename.unix.*"
+platform = "linux"
+
+[[tool.mypy.overrides]]
+module = "find_system_fonts_filename.windows.*"
+platform = "win32"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,12 @@ dynamic = ["version"]
 Source = "https://github.com/moi15moi/FindSystemFontsFilename/"
 Tracker = "https://github.com/moi15moi/FindSystemFontsFilename/issues/"
 
+[project.optional-dependencies]
+dev = [
+  "mypy>=1.0.0",
+  "pytest>=8.0.0",
+]
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
@junkmd Do you have any idea how I can remove all the typing errors caused by `comtypes`?  

Currently, I simply ignore all errors that look like this:  
```py
find_system_fonts_filename\windows\windows_fonts.py:51: error: "_Pointer[IDWriteFontFile]" has no attribute "GetLoader"  [attr-defined]
```  

However, I was wondering if there’s a way to properly fix these errors. Even if I replace `POINTER[...]` with `POINTER(...)`, I still get other errors, such as:  
```py
find_system_fonts_filename\windows\windows_fonts.py:316: error: Invalid type comment or annotation  [valid-type]
find_system_fonts_filename\windows\windows_fonts.py:316: note: Suggestion: use POINTER[...] instead of POINTER(...)
```  

Would appreciate any insights!