### PR TITLE
Replace cdll with CDLL and windll with WinDLL

### DIFF
--- a/find_system_fonts_filename/android/android.py
+++ b/find_system_fonts_filename/android/android.py
@@ -1,4 +1,4 @@
-from ctypes import c_char_p, c_void_p, cdll, util
+from ctypes import c_char_p, c_void_p, CDLL, util
 from ..exceptions import AndroidLibraryNotFound, OSNotSupported
 
 __all__ = ["Android"]
@@ -12,7 +12,7 @@ class Android():
         if android_library_name is None:
             raise AndroidLibraryNotFound("You need to have the libandroid library. It is only available since the SDK/API level 29.")
 
-        android = cdll.LoadLibrary(android_library_name)
+        android = CDLL(android_library_name)
 
         try:
             # https://developer.android.com/ndk/reference/group/font#asystemfontiterator_open

--- a/find_system_fonts_filename/mac/core_foundation.py
+++ b/find_system_fonts_filename/mac/core_foundation.py
@@ -1,5 +1,5 @@
 from .types import CFIndex, CFNumberRef, CFStringEncoding
-from ctypes import c_bool, c_char_p, c_void_p, cdll, util
+from ctypes import c_bool, c_char_p, c_void_p, CDLL, util
 from enum import IntEnum
 
 __all__ = [
@@ -63,7 +63,7 @@ class CoreFoundation():
         # From: https://github.com/pyglet/pyglet/blob/a44e83a265e7df8ece793de865bcf3690f66adbd/pyglet/libs/darwin/cocoapy/cocoalibs.py#L10-L14
         if core_foundation_library_name is None:
             core_foundation_library_name = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
-        core_foundation = cdll.LoadLibrary(core_foundation_library_name)
+        core_foundation = CDLL(core_foundation_library_name)
 
 
         # https://developer.apple.com/documentation/corefoundation/1521153-cfrelease

--- a/find_system_fonts_filename/mac/core_text.py
+++ b/find_system_fonts_filename/mac/core_text.py
@@ -1,5 +1,5 @@
 from .types import CFIndex
-from ctypes import c_bool, c_uint32, c_void_p, cdll, util
+from ctypes import c_bool, c_uint32, c_void_p, CDLL, util
 from enum import IntEnum
 
 __all__ = [
@@ -35,7 +35,7 @@ class CoreText():
         # From: https://github.com/pyglet/pyglet/blob/a44e83a265e7df8ece793de865bcf3690f66adbd/pyglet/libs/darwin/cocoapy/cocoalibs.py#L520-L524
         if core_text_library_name is None:
             core_text_library_name = "/System/Library/Frameworks/CoreText.framework/CoreText"
-        core_text = cdll.LoadLibrary(core_text_library_name)
+        core_text = CDLL(core_text_library_name)
 
         self.kCTFontURLAttribute = c_void_p.in_dll(core_text, "kCTFontURLAttribute")
         self.kCTFontFormatAttribute = c_void_p.in_dll(core_text, "kCTFontFormatAttribute")

--- a/find_system_fonts_filename/unix/fontconfig.py
+++ b/find_system_fonts_filename/unix/fontconfig.py
@@ -1,4 +1,4 @@
-from ctypes import c_char_p, c_int, c_void_p, cdll, POINTER, Structure, util
+from ctypes import c_char_p, c_int, c_void_p, CDLL, POINTER, Structure, util
 from enum import Enum, IntEnum
 from ..exceptions import FontConfigNotFound
 
@@ -50,7 +50,7 @@ class FontConfig():
         if font_config_library_name is None:
             raise FontConfigNotFound("You need to install FontConfig to get the fonts filename")
 
-        font_config = cdll.LoadLibrary(font_config_library_name)
+        font_config = CDLL(font_config_library_name)
 
         self.FC_FONTFORMAT = FontConfig.string_to_cstring("fontformat")
         self.FC_FILE = FontConfig.string_to_cstring("file")

--- a/find_system_fonts_filename/windows/advapi32.py
+++ b/find_system_fonts_filename/windows/advapi32.py
@@ -1,4 +1,4 @@
-from ctypes import windll, wintypes
+from ctypes import WinDLL, wintypes
 from enum import Enum
 from ..exceptions import SystemApiError
 
@@ -26,7 +26,7 @@ class RegistryDataType(Enum):
 
 class Advapi32():
     def __init__(self) -> None:
-        advapi32 = windll.LoadLibrary("advapi32")
+        advapi32 = WinDLL("advapi32")
 
         self.HKEY_CURRENT_USER = wintypes.HKEY(0x80000001)
         self.KEY_SET_VALUE = 0x0002

--- a/find_system_fonts_filename/windows/dwrite.py
+++ b/find_system_fonts_filename/windows/dwrite.py
@@ -1,6 +1,6 @@
 from .gdi32 import LOGFONTW
 from comtypes import GUID, HRESULT, IID, IUnknown, STDMETHOD
-from ctypes import POINTER, windll, wintypes
+from ctypes import POINTER, WinDLL, wintypes
 from enum import IntEnum, IntFlag
 
 __all__ = [
@@ -342,7 +342,7 @@ class IDWriteFactory3(IDWriteFactory2):
 
 class DWrite:
     def __init__(self) -> None:
-        dwrite = windll.LoadLibrary("dwrite")
+        dwrite = WinDLL("dwrite")
 
         # https://learn.microsoft.com/en-us/windows/win32/api/dwrite/nf-dwrite-dwritecreatefactory
         self.DWriteCreateFactory = dwrite.DWriteCreateFactory

--- a/find_system_fonts_filename/windows/gdi32.py
+++ b/find_system_fonts_filename/windows/gdi32.py
@@ -1,4 +1,4 @@
-from ctypes import POINTER, WINFUNCTYPE, c_ubyte, Structure, windll, wintypes
+from ctypes import POINTER, WINFUNCTYPE, c_ubyte, Structure, WinDLL, wintypes
 from ..exceptions import SystemApiError
 
 __all__ = ["GDI32"]
@@ -62,7 +62,7 @@ class ENUMLOGFONTEXW(Structure):
 
 class GDI32:
     def __init__(self) -> None:
-        gdi = windll.LoadLibrary("gdi32")
+        gdi = WinDLL("gdi32")
 
         self.LF_FACESIZE = 32
         self.RASTER_FONTTYPE = 0x0001

--- a/find_system_fonts_filename/windows/kernel32.py
+++ b/find_system_fonts_filename/windows/kernel32.py
@@ -1,4 +1,4 @@
-from ctypes import windll, wintypes
+from ctypes import WinDLL, wintypes
 from ..exceptions import SystemApiError
 
 __all__ = ["Kernel32"]
@@ -6,7 +6,7 @@ __all__ = ["Kernel32"]
 
 class Kernel32():
     def __init__(self) -> None:
-        kernel32 = windll.LoadLibrary("kernel32")
+        kernel32 = WinDLL("kernel32")
 
         self.LOCALE_NAME_MAX_LENGTH = 85
 

--- a/find_system_fonts_filename/windows/msvcrt.py
+++ b/find_system_fonts_filename/windows/msvcrt.py
@@ -1,4 +1,4 @@
-from ctypes import c_size_t, windll, wintypes
+from ctypes import c_size_t, WinDLL, wintypes
 from ..exceptions import SystemApiError
 
 __all__ = ["MSVCRT"]
@@ -6,7 +6,7 @@ __all__ = ["MSVCRT"]
 
 class MSVCRT:
     def __init__(self) -> None:
-        msvcrt = windll.LoadLibrary("msvcrt")
+        msvcrt = WinDLL("msvcrt")
 
         # https://learn.microsoft.com/fr-fr/cpp/c-runtime-library/reference/strncpy-s-strncpy-s-l-wcsncpy-s-wcsncpy-s-l-mbsncpy-s-mbsncpy-s-l?view=msvc-170
         self.wcsncpy_s = msvcrt.wcsncpy_s

--- a/find_system_fonts_filename/windows/user32.py
+++ b/find_system_fonts_filename/windows/user32.py
@@ -1,4 +1,4 @@
-from ctypes import windll, wintypes
+from ctypes import WinDLL, wintypes
 from ..exceptions import SystemApiError
 
 __all__ = ["User32"]
@@ -6,7 +6,7 @@ __all__ = ["User32"]
 
 class User32():
     def __init__(self) -> None:
-        user32 = windll.LoadLibrary("user32")
+        user32 = WinDLL("user32")
 
         self.HWND_BROADCAST = wintypes.HWND(0xFFFF)
         self.WM_FONTCHANGE = wintypes.UINT(0x001D)


### PR DESCRIPTION
As noted in [this comment](https://github.com/python/cpython/issues/125788#issuecomment-2427769349), it is preferable to use `ctypes.WinDLL` instead of `ctypes.windll`. This approach avoids modifying shared DLL objects and ensures better isolation.